### PR TITLE
Fix header declaration

### DIFF
--- a/src/jermbox.c
+++ b/src/jermbox.c
@@ -1,4 +1,4 @@
-#include <janet/janet.h>
+#include <janet.h>
 #include <stdio.h>
 #include "../termbox_next/src/termbox.h"
 


### PR DESCRIPTION
Having `janet/janit.h` only works when janet is installed via the system package manager. by changing it to `janet.h` we allow for non-standard installations to work (such as `asdf`)