### PR TITLE
fixed set-clear-attributes for true-color output

### DIFF
--- a/src/jermbox.c
+++ b/src/jermbox.c
@@ -138,8 +138,8 @@ cfun_tb_clear (int32_t argc, Janet *argv) {
 static Janet
 cfun_tb_set_clear_attributes (int32_t argc, Janet *argv) {
   janet_fixarity(argc, 2);
-  uint16_t fg = (uint16_t) janet_getinteger(argv, 0);
-  uint16_t bg = (uint16_t) janet_getinteger(argv, 1);
+  uint32_t fg = (uint32_t) janet_getinteger(argv, 0); // TODO!!!!
+  uint32_t bg = (uint32_t) janet_getinteger(argv, 1);
 
   tb_set_clear_attributes(fg, bg);
   return janet_wrap_nil();


### PR DESCRIPTION
True-colors were truncated due to the use of an uint16 instead of an uint32, which meant the value for red was always 0